### PR TITLE
fix(cart,pizza): correct 50/50 names and hide redundant "no topping" tile

### DIFF
--- a/components_new/cart/CartApp.tsx
+++ b/components_new/cart/CartApp.tsx
@@ -7,6 +7,7 @@ import axios from 'axios'
 import defaultChannel from '@lib/defaultChannel'
 import currency from 'currency.js'
 import getAssetUrl from '@utils/getAssetUrl'
+import { composeHalfPizzaName } from '@lib/utils/composeHalfPizzaName'
 import { useCartStore, cartSelectors } from '../../lib/stores/cart-store'
 import {
   useAddToCart,
@@ -412,8 +413,7 @@ export default function CartApp(_props: CartAppProps) {
           return a?.[locale] || a?.['ru'] || ''
         })
         .filter(Boolean)
-        .join(' + ')
-      return extras ? `${main} + ${extras}` : main
+      return composeHalfPizzaName([main, ...extras])
     }
     return main
   }

--- a/components_new/common/SmallCartApp.tsx
+++ b/components_new/common/SmallCartApp.tsx
@@ -17,6 +17,7 @@ import { useUserStore } from '../../lib/stores/user-store'
 import { useLocationStore } from '../../lib/stores/location-store'
 import { useUIStore } from '../../lib/stores/ui-store'
 import { pickProductImage } from '@utils/getAssetUrl'
+import { composeHalfPizzaName } from '@lib/utils/composeHalfPizzaName'
 import { toast } from 'sonner'
 import { useIsWithinWorkHours } from '../../lib/utils/isWorkTime'
 import { storefrontConfig as configData } from '../../lib/data/storefront-config'
@@ -273,22 +274,23 @@ const SmallCartApp: FC<SmallCartProps> = ({ channelName }) => {
                           </div>
                         )}
                         <div className="font-bold text-xs">
-                          {lineItem.child && lineItem.child.length > 1
-                            ? `${
+                          {lineItem.child && lineItem.child.length === 1
+                            ? composeHalfPizzaName([
                                 lineItem?.variant?.product?.attribute_data
-                                  ?.name[channelName][locale || 'ru']
-                              }  ${lineItem?.child
-                                .filter(
-                                  (v: any) =>
-                                    lineItem?.variant?.product?.box_id !=
-                                    v?.variant?.product?.id
-                                )
-                                .map(
-                                  (v: any) =>
-                                    v?.variant?.product?.attribute_data?.name[
-                                      channelName
-                                    ][locale || 'ru']
-                                )} `
+                                  ?.name[channelName][locale || 'ru'],
+                                ...lineItem?.child
+                                  .filter(
+                                    (v: any) =>
+                                      lineItem?.variant?.product?.box_id !=
+                                      v?.variant?.product?.id
+                                  )
+                                  .map(
+                                    (v: any) =>
+                                      v?.variant?.product?.attribute_data?.name[
+                                        channelName
+                                      ][locale || 'ru']
+                                  ),
+                              ])
                             : lineItem?.variant?.product?.attribute_data?.name[
                                 channelName
                               ][locale || 'ru']}

--- a/components_new/product/CreateYourPizzaApp.tsx
+++ b/components_new/product/CreateYourPizzaApp.tsx
@@ -405,6 +405,14 @@ const CreateYourPizzaApp: FC<CreatePizzaProps> = ({
       }
     }
 
+    // "Без доп начинки" (price 0) is shown inconsistently across sizes by the
+    // backend (40см has the id-70 modifier, 30/35 don't) — DAV-631. Per product
+    // decision, hide it entirely on every size: "no extra topping" is already
+    // the default state (empty selection), so the tile is redundant.
+    if (leftModifiers) {
+      leftModifiers = leftModifiers.filter((m: any) => +m.price !== 0)
+    }
+
     if (leftModifiers) {
       leftModifiers.sort(function (a: any, b: any) {
         if (+a.price > +b.price) {

--- a/components_new/product/CreateYourPizzaMobileApp.tsx
+++ b/components_new/product/CreateYourPizzaMobileApp.tsx
@@ -321,6 +321,14 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
       }
     }
 
+    // "Без доп начинки" (price 0) is shown inconsistently across sizes by the
+    // backend (40см has the id-70 modifier, 30/35 don't) — DAV-631. Per product
+    // decision, hide it entirely on every size: "no extra topping" is already
+    // the default state (empty selection), so the tile is redundant.
+    if (leftModifiers) {
+      leftModifiers = leftModifiers.filter((m: any) => +m.price !== 0)
+    }
+
     if (leftModifiers) {
       leftModifiers.sort(function (a: any, b: any) {
         if (+a.price > +b.price) {
@@ -549,35 +557,63 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                         </div>
                       </div>
                       <div className="mt-4 text-lg font-semibold text-center">
-                        {leftSelectedProduct?.attribute_data?.name[channelName][locale || 'ru']}
+                        {
+                          leftSelectedProduct?.attribute_data?.name[
+                            channelName
+                          ][locale || 'ru']
+                        }
                         {' + '}
-                        {rightSelectedProduct?.attribute_data?.name[channelName][locale || 'ru']}
+                        {
+                          rightSelectedProduct?.attribute_data?.name[
+                            channelName
+                          ][locale || 'ru']
+                        }
                       </div>
-                      {(leftSelectedProduct?.attribute_data?.description?.[channelName]?.[locale || 'ru'] ||
-                        rightSelectedProduct?.attribute_data?.description?.[channelName]?.[locale || 'ru']) && (
+                      {(leftSelectedProduct?.attribute_data?.description?.[
+                        channelName
+                      ]?.[locale || 'ru'] ||
+                        rightSelectedProduct?.attribute_data?.description?.[
+                          channelName
+                        ]?.[locale || 'ru']) && (
                         <div className="divide-y space-y-2 mt-2">
-                          {leftSelectedProduct?.attribute_data?.description?.[channelName]?.[locale || 'ru'] && (
+                          {leftSelectedProduct?.attribute_data?.description?.[
+                            channelName
+                          ]?.[locale || 'ru'] && (
                             <div className="pt-2">
                               <div className="text-sm font-medium">
-                                {leftSelectedProduct?.attribute_data?.name[channelName][locale || 'ru']}
+                                {
+                                  leftSelectedProduct?.attribute_data?.name[
+                                    channelName
+                                  ][locale || 'ru']
+                                }
                               </div>
                               <div
                                 className="text-xs text-gray-400"
                                 dangerouslySetInnerHTML={{
-                                  __html: leftSelectedProduct.attribute_data.description[channelName][locale || 'ru'],
+                                  __html:
+                                    leftSelectedProduct.attribute_data
+                                      .description[channelName][locale || 'ru'],
                                 }}
                               ></div>
                             </div>
                           )}
-                          {rightSelectedProduct?.attribute_data?.description?.[channelName]?.[locale || 'ru'] && (
+                          {rightSelectedProduct?.attribute_data?.description?.[
+                            channelName
+                          ]?.[locale || 'ru'] && (
                             <div className="pt-2">
                               <div className="text-sm font-medium">
-                                {rightSelectedProduct?.attribute_data?.name[channelName][locale || 'ru']}
+                                {
+                                  rightSelectedProduct?.attribute_data?.name[
+                                    channelName
+                                  ][locale || 'ru']
+                                }
                               </div>
                               <div
                                 className="text-xs text-gray-400"
                                 dangerouslySetInnerHTML={{
-                                  __html: rightSelectedProduct.attribute_data.description[channelName][locale || 'ru'],
+                                  __html:
+                                    rightSelectedProduct.attribute_data
+                                      .description[channelName][locale || 'ru'],
                                 }}
                               ></div>
                             </div>
@@ -590,53 +626,56 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                             <span>{'Добавить к пицце'}</span>
                           </div>
                           <div className="grid grid-cols-4 gap-2">
-                            {modifiers.filter((mod: any) => mod.price > 0).map((mod: any) => (
-                              <div
-                                key={mod.id}
-                                className={`border ${
-                                  activeModifiers.includes(mod.id) ||
-                                  (!activeModifiers.length && mod.price == 0)
-                                    ? 'border-yellow'
-                                    : 'border-gray-300'
-                                } flex flex-col justify-between overflow-hidden rounded-[15px] cursor-pointer`}
-                                onClick={() => addModifier(mod.id)}
-                              >
-                                <div className="flex-grow pt-2 px-2 flex justify-center">
-                                  <img
-                                    src={getAssetUrl(mod.assets)}
-                                    width={80}
-                                    height={80}
-                                    alt={mod.name}
-                                  />
-                                </div>
-                                <div className="px-2 text-center text-xs pb-1">
-                                  {locale == 'uz'
-                                    ? mod.name_uz || mod.name
-                                    : locale == 'en'
-                                    ? mod.name_en || mod.name
-                                    : mod.name_ru || mod.name}
-                                </div>
+                            {modifiers
+                              .filter((mod: any) => mod.price > 0)
+                              .map((mod: any) => (
                                 <div
-                                  className={`${
+                                  key={mod.id}
+                                  className={`border ${
                                     activeModifiers.includes(mod.id) ||
                                     (!activeModifiers.length && mod.price == 0)
-                                      ? 'bg-yellow'
-                                      : 'bg-gray-300'
-                                  } font-bold px-4 py-2 text-center text-white text-xs`}
+                                      ? 'border-yellow'
+                                      : 'border-gray-300'
+                                  } flex flex-col justify-between overflow-hidden rounded-[15px] cursor-pointer`}
+                                  onClick={() => addModifier(mod.id)}
                                 >
-                                  {currency(mod.price, {
-                                    pattern: '# !',
-                                    separator: ' ',
-                                    decimal: '.',
-                                    symbol: `${locale == 'uz' ? "so'm" : ''}
+                                  <div className="flex-grow pt-2 px-2 flex justify-center">
+                                    <img
+                                      src={getAssetUrl(mod.assets)}
+                                      width={80}
+                                      height={80}
+                                      alt={mod.name}
+                                    />
+                                  </div>
+                                  <div className="px-2 text-center text-xs pb-1">
+                                    {locale == 'uz'
+                                      ? mod.name_uz || mod.name
+                                      : locale == 'en'
+                                      ? mod.name_en || mod.name
+                                      : mod.name_ru || mod.name}
+                                  </div>
+                                  <div
+                                    className={`${
+                                      activeModifiers.includes(mod.id) ||
+                                      (!activeModifiers.length &&
+                                        mod.price == 0)
+                                        ? 'bg-yellow'
+                                        : 'bg-gray-300'
+                                    } font-bold px-4 py-2 text-center text-white text-xs`}
+                                  >
+                                    {currency(mod.price, {
+                                      pattern: '# !',
+                                      separator: ' ',
+                                      decimal: '.',
+                                      symbol: `${locale == 'uz' ? "so'm" : ''}
                                       ${locale == 'ru' ? 'сум' : ''}
                                       ${locale == 'en' ? 'sum' : ''}
                                       `,
-                                    precision: 0,
-                                  }).format()}
+                                      precision: 0,
+                                    }).format()}
+                                  </div>
                                 </div>
-                              </div>
-                            ))}
+                              ))}
                           </div>
                         </div>
                       )}
@@ -696,7 +735,11 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                   <>
                     <div className="flex w-full max-h-32 flex-col">
                       <div className="flex w-full items-center">
-                        <button onClick={closeModal} className="flex p-2 z-10 relative" type="button">
+                        <button
+                          onClick={closeModal}
+                          className="flex p-2 z-10 relative"
+                          type="button"
+                        >
                           <img
                             src="/assets/back.png"
                             width="24"
@@ -730,7 +773,10 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                         <div className="flex items-center justify-center">
                           <div className="relative w-32 h-32">
                             {leftSelectedProduct ? (
-                              <div className="absolute inset-0 overflow-hidden" style={{ clipPath: 'inset(0 50% 0 0)' }}>
+                              <div
+                                className="absolute inset-0 overflow-hidden"
+                                style={{ clipPath: 'inset(0 50% 0 0)' }}
+                              >
                                 <img
                                   src={leftSelectedProduct.image}
                                   className="w-32 h-32 object-contain"
@@ -738,14 +784,22 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                                 />
                               </div>
                             ) : (
-                              <div className="absolute inset-0 overflow-hidden" style={{ clipPath: 'inset(0 50% 0 0)' }}>
+                              <div
+                                className="absolute inset-0 overflow-hidden"
+                                style={{ clipPath: 'inset(0 50% 0 0)' }}
+                              >
                                 <div className="w-32 h-32 rounded-full bg-gray-100 flex items-center justify-center">
-                                  <span className="text-gray-300 text-3xl">?</span>
+                                  <span className="text-gray-300 text-3xl">
+                                    ?
+                                  </span>
                                 </div>
                               </div>
                             )}
                             {rightSelectedProduct ? (
-                              <div className="absolute inset-0 overflow-hidden" style={{ clipPath: 'inset(0 0 0 50%)' }}>
+                              <div
+                                className="absolute inset-0 overflow-hidden"
+                                style={{ clipPath: 'inset(0 0 0 50%)' }}
+                              >
                                 <img
                                   src={rightSelectedProduct.image}
                                   className="w-32 h-32 object-contain"
@@ -753,9 +807,14 @@ const CreateYourPizzaMobileApp: FC<CreatePizzaProps> = ({
                                 />
                               </div>
                             ) : (
-                              <div className="absolute inset-0 overflow-hidden" style={{ clipPath: 'inset(0 0 0 50%)' }}>
+                              <div
+                                className="absolute inset-0 overflow-hidden"
+                                style={{ clipPath: 'inset(0 0 0 50%)' }}
+                              >
                                 <div className="w-32 h-32 rounded-full bg-gray-100 flex items-center justify-center">
-                                  <span className="text-gray-300 text-3xl">?</span>
+                                  <span className="text-gray-300 text-3xl">
+                                    ?
+                                  </span>
                                 </div>
                               </div>
                             )}

--- a/lib/utils/composeHalfPizzaName.ts
+++ b/lib/utils/composeHalfPizzaName.ts
@@ -1,0 +1,40 @@
+const SEP = ' + '
+
+/**
+ * Joins the localized names of a multi-half pizza (50/50) and collapses a
+ * trailing add-on that every half repeats.
+ *
+ * Backend "modifier-as-product" variants bake the add-on into the product
+ * name itself — e.g. the sausage-crust variant of "Грибная 40" is named
+ * "Грибная 40 + Сосисочный борт". For a 50/50 pizza the constructor swaps
+ * BOTH halves to their crust variant, so naively joining the halves repeats
+ * the crust:
+ *   "Ханская 40 + Сосисочный борт + Комбо 40 + Сосисочный борт"   ← DAV-633
+ *
+ * When every segment shares the same trailing " + X", emit X once at the end:
+ *   "Ханская 40 + Комбо 40 + Сосисочный борт"
+ *
+ * Locale-agnostic by design — the crust suffix differs per locale
+ * (ru "Сосисочный борт" / uz "sosiskali bo'rt" / en "Sausage crust"), so we
+ * compare the trailing segment instead of matching hardcoded strings.
+ * Conservative: if the halves don't all share the same trailing segment
+ * (e.g. only one half has a crust), nothing is collapsed.
+ */
+export function composeHalfPizzaName(
+  names: (string | undefined | null)[]
+): string {
+  const parts = names.map((n) => String(n ?? '').trim()).filter(Boolean)
+  if (parts.length <= 1) return parts.join(SEP)
+
+  const split = parts.map((n) => n.split(SEP))
+  const lastOf = (segs: string[]) => segs[segs.length - 1]
+  const suffix = lastOf(split[0])
+  const allShareSuffix = split.every(
+    (segs) => segs.length > 1 && lastOf(segs) === suffix
+  )
+
+  if (!allShareSuffix) return parts.join(SEP)
+
+  const bases = split.map((segs) => segs.slice(0, -1).join(SEP))
+  return `${bases.join(SEP)}${SEP}${suffix}`
+}


### PR DESCRIPTION
Fixes three Multica tickets on the 50/50 pizza flow. Already deployed to prod from this branch; merging to keep the fixes after future `main` deploys.

## DAV-633 — cart duplicates "Сосисочный борт" on 50/50
Sausage-crust products carry the suffix in their backend name ("Грибная 40 + Сосисочный борт"); a 50/50 swaps both halves to their crust variant, so joining halves repeated the crust. New `lib/utils/composeHalfPizzaName` collapses a shared trailing add-on so it shows once.

## DAV-632 — mini-cart shows only one half of a 50/50 name
`SmallCartApp` gated the name join on `child.length > 1`, but a standard 50/50 has exactly one child. Mirrors `CartApp`'s `=== 1` logic via the shared helper.

## DAV-631 — "Без доп начинки" inconsistent + co-active with toppings
The price-0 modifier is defined only on 40см in the backend and could stay highlighted next to a paid topping. Hidden on every size in both pizza constructors (desktop + mobile) — "no extra topping" is already the default empty selection, so nothing is sent to the basket for it.

Verified: production build green (compile + typecheck + 98 SSG pages), confirmed live on choparpizza.uz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)