### PR TITLE
fix: cart/checkout batch — address reset, add-to-cart crash, cart images, profile orders

### DIFF
--- a/components_new/cart/CartApp.tsx
+++ b/components_new/cart/CartApp.tsx
@@ -6,7 +6,7 @@ import { Link, useRouter } from '../../i18n/navigation'
 import axios from 'axios'
 import defaultChannel from '@lib/defaultChannel'
 import currency from 'currency.js'
-import getAssetUrl from '@utils/getAssetUrl'
+import { pickProductImage } from '@utils/getAssetUrl'
 import { composeHalfPizzaName } from '@lib/utils/composeHalfPizzaName'
 import { useCartStore, cartSelectors } from '../../lib/stores/cart-store'
 import {
@@ -434,14 +434,14 @@ export default function CartApp(_props: CartAppProps) {
         return (
           <div className="w-16 h-16 relative rounded-2xl bg-gray-50 overflow-hidden flex-shrink-0">
             <img
-              src={getAssetUrl(line?.variant?.product?.assets)}
+              src={pickProductImage(line?.variant?.product)}
               className="absolute inset-0 m-auto w-10 h-10 object-contain rounded-full"
               alt=""
             />
             {child.map((c: any, i: number) => (
               <img
                 key={i}
-                src={getAssetUrl(c?.variant?.product?.assets)}
+                src={pickProductImage(c?.variant?.product)}
                 className="absolute w-8 h-8 object-contain rounded-full bg-white"
                 style={{
                   right: i * 6,
@@ -457,14 +457,14 @@ export default function CartApp(_props: CartAppProps) {
         <div className="w-16 h-16 flex rounded-2xl bg-gray-50 overflow-hidden flex-shrink-0">
           <div className="w-1/2 relative overflow-hidden">
             <img
-              src={getAssetUrl(line?.variant?.product?.assets)}
+              src={pickProductImage(line?.variant?.product)}
               className="absolute h-full max-w-none left-0"
               alt=""
             />
           </div>
           <div className="w-1/2 relative overflow-hidden">
             <img
-              src={getAssetUrl(child[0]?.variant?.product?.assets)}
+              src={pickProductImage(child[0]?.variant?.product)}
               className="absolute h-full max-w-none right-0"
               alt=""
             />
@@ -475,7 +475,7 @@ export default function CartApp(_props: CartAppProps) {
     return (
       <div className="w-16 h-16 rounded-2xl bg-gray-50 flex items-center justify-center overflow-hidden flex-shrink-0">
         <img
-          src={getAssetUrl(line?.variant?.product?.assets)}
+          src={pickProductImage(line?.variant?.product)}
           className="max-w-full max-h-full object-contain"
           alt=""
         />

--- a/components_new/common/SmallCartApp.tsx
+++ b/components_new/common/SmallCartApp.tsx
@@ -18,6 +18,7 @@ import { useLocationStore } from '../../lib/stores/location-store'
 import { useUIStore } from '../../lib/stores/ui-store'
 import { pickProductImage } from '@utils/getAssetUrl'
 import { composeHalfPizzaName } from '@lib/utils/composeHalfPizzaName'
+import { pickProductName } from '@lib/utils/pickProductName'
 import { toast } from 'sonner'
 import { useIsWithinWorkHours } from '../../lib/utils/isWorkTime'
 import { storefrontConfig as configData } from '../../lib/data/storefront-config'
@@ -276,24 +277,30 @@ const SmallCartApp: FC<SmallCartProps> = ({ channelName }) => {
                         <div className="font-bold text-xs">
                           {lineItem.child && lineItem.child.length === 1
                             ? composeHalfPizzaName([
-                                lineItem?.variant?.product?.attribute_data
-                                  ?.name[channelName][locale || 'ru'],
+                                pickProductName(
+                                  lineItem?.variant?.product,
+                                  channelName,
+                                  locale
+                                ),
                                 ...lineItem?.child
                                   .filter(
                                     (v: any) =>
                                       lineItem?.variant?.product?.box_id !=
                                       v?.variant?.product?.id
                                   )
-                                  .map(
-                                    (v: any) =>
-                                      v?.variant?.product?.attribute_data?.name[
-                                        channelName
-                                      ][locale || 'ru']
+                                  .map((v: any) =>
+                                    pickProductName(
+                                      v?.variant?.product,
+                                      channelName,
+                                      locale
+                                    )
                                   ),
                               ])
-                            : lineItem?.variant?.product?.attribute_data?.name[
-                                channelName
-                              ][locale || 'ru']}
+                            : pickProductName(
+                                lineItem?.variant?.product,
+                                channelName,
+                                locale
+                              )}
                           {'  '}
                           {lineItem.bonus_id && (
                             <span className="text-yellow">({'Бонус'})</span>

--- a/components_new/header/LocationPickerCore.tsx
+++ b/components_new/header/LocationPickerCore.tsx
@@ -277,6 +277,10 @@ const LocationPickerCore: FC<Props> = ({
     setSelectedAddressId(null)
     setSuggestions([])
     resolveNearest(lat, lon)
+    // New address → previous apartment details no longer apply (DAV-625).
+    setFlat('')
+    setEntrance('')
+    setDoorCode('')
   }
 
   // Pick a saved address (DAV-628) — fill the form from it instead of
@@ -319,6 +323,10 @@ const LocationPickerCore: FC<Props> = ({
     setCoords([lat, lon])
     setSelectedAddressId(null)
     resolveNearest(lat, lon)
+    // New location → previous apartment details no longer apply (DAV-625).
+    setFlat('')
+    setEntrance('')
+    setDoorCode('')
     try {
       const { data } = await axios.get(`/api/geocode?lat=${lat}&lon=${lon}`)
       const item = Array.isArray(data) ? data[0] : data

--- a/components_new/order/OrderAcceptApp.tsx
+++ b/components_new/order/OrderAcceptApp.tsx
@@ -8,6 +8,7 @@ import { Link } from '../../i18n/navigation'
 import { useForm } from 'react-hook-form'
 import currency from 'currency.js'
 import defaultChannel from '@lib/defaultChannel'
+import { pickProductName } from '@lib/utils/pickProductName'
 import { DateTime } from 'luxon'
 import Cookies from 'js-cookie'
 import axios from 'axios'
@@ -170,7 +171,10 @@ const OrderAcceptApp: FC<OrderDetailProps> = ({
 
   useEffect(() => {
     getChannel()
-    if (!initialOrderStatuses || Object.keys(initialOrderStatuses).length === 0) {
+    if (
+      !initialOrderStatuses ||
+      Object.keys(initialOrderStatuses).length === 0
+    ) {
       fetchOrderStatuses()
     }
     if (!order && orderId) {
@@ -264,15 +268,15 @@ const OrderAcceptApp: FC<OrderDetailProps> = ({
             {isUnauthorized
               ? 'Войдите в аккаунт'
               : orderLoadError === 'not_found'
-                ? 'Заказ не найден'
-                : 'Не удалось загрузить заказ'}
+              ? 'Заказ не найден'
+              : 'Не удалось загрузить заказ'}
           </h1>
           <p className="text-gray-500 mb-6">
             {isUnauthorized
               ? 'Чтобы открыть детали заказа, нужно войти в личный кабинет.'
               : orderLoadError === 'not_found'
-                ? 'Проверьте ссылку или вернитесь к списку заказов.'
-                : 'Попробуйте обновить страницу. Если проблема повторится — напишите нам.'}
+              ? 'Проверьте ссылку или вернитесь к списку заказов.'
+              : 'Попробуйте обновить страницу. Если проблема повторится — напишите нам.'}
           </p>
           <div className="flex items-center justify-center gap-3">
             {!isUnauthorized && orderId && (
@@ -405,8 +409,7 @@ const OrderAcceptApp: FC<OrderDetailProps> = ({
       {/* Order items */}
       <div className="md:p-10 p-4 rounded-2xl md:text-xl mt-1 md:mt-5 bg-white">
         <div className="text-base md:text-lg mb-4 md:mb-10 font-bold">
-          {order?.basket?.lines.length} товар{' '}
-          {locale == 'ru' ? 'на' : ''}{' '}
+          {order?.basket?.lines.length} товар {locale == 'ru' ? 'на' : ''}{' '}
           {currency(order?.order_total / 100, {
             pattern: '# !',
             separator: ' ',
@@ -488,26 +491,29 @@ const OrderAcceptApp: FC<OrderDetailProps> = ({
               <div className="ml-3 md:ml-5 flex-1 min-w-0">
                 <div className="text-sm md:text-xl font-bold">
                   {pizza.child && pizza.child.length > 1
-                    ? `${
-                        pizza?.variant?.product?.attribute_data?.name[
-                          channelName
-                        ][locale || 'ru']
-                      } + ${pizza?.child
+                    ? `${pickProductName(
+                        pizza?.variant?.product,
+                        channelName,
+                        locale
+                      )} + ${pizza?.child
                         .filter(
                           (v: any) =>
                             pizza?.variant?.product?.box_id !=
                             v?.variant?.product?.id
                         )
-                        .map(
-                          (v: any) =>
-                            v?.variant?.product?.attribute_data?.name[
-                              channelName
-                            ][locale || 'ru']
+                        .map((v: any) =>
+                          pickProductName(
+                            v?.variant?.product,
+                            channelName,
+                            locale
+                          )
                         )
                         .join(' + ')}`
-                    : pizza?.variant?.product?.attribute_data?.name[
-                        channelName
-                      ][locale || 'ru']}{' '}
+                    : pickProductName(
+                        pizza?.variant?.product,
+                        channelName,
+                        locale
+                      )}{' '}
                   {pizza.bonus_id && (
                     <span className="text-yellow">(Бонус)</span>
                   )}

--- a/components_new/order/OrdersApp.tsx
+++ b/components_new/order/OrdersApp.tsx
@@ -618,6 +618,10 @@ const OrdersApp: FC<OrdersProps> = ({ channelName, isMobile = false }) => {
         house = address.name
       }
     })
+    // New address → previous apartment details no longer apply (DAV-625).
+    setValue('flat', '')
+    setValue('entrance', '')
+    setValue('door_code', '')
     let terminalData = await searchTerminal(
       {
         location: [selection.coordinates.lat, selection.coordinates.long],
@@ -628,6 +632,9 @@ const OrdersApp: FC<OrdersProps> = ({ channelName, isMobile = false }) => {
       ...locationData,
       deliveryType: tabIndex,
       house: house,
+      flat: '',
+      entrance: '',
+      door_code: '',
       location: [selection.coordinates.lat, selection.coordinates.long],
       terminal_id: terminalData.terminal_id,
       terminalData: terminalData.terminalData,
@@ -683,6 +690,10 @@ const OrdersApp: FC<OrdersProps> = ({ channelName, isMobile = false }) => {
     })
     setValue('house', house)
     setValue('address', data.data.formatted)
+    // New location → previous apartment details no longer apply (DAV-625).
+    setValue('flat', '')
+    setValue('entrance', '')
+    setValue('door_code', '')
     downshiftControl?.current?.reset({
       inputValue: data.data.formatted,
     })
@@ -699,6 +710,9 @@ const OrdersApp: FC<OrdersProps> = ({ channelName, isMobile = false }) => {
       location: coords,
       address: data.data.formatted,
       house,
+      flat: '',
+      entrance: '',
+      door_code: '',
       terminal_id: terminalData.terminal_id,
       terminalData: terminalData.terminalData,
     })

--- a/components_new/profile/OrdersApp.tsx
+++ b/components_new/profile/OrdersApp.tsx
@@ -8,14 +8,17 @@ import Hashids from 'hashids'
 import { DateTime } from 'luxon'
 import currency from 'currency.js'
 import axios from 'axios'
-import Cookies from 'js-cookie'
+import { getOptToken } from '../../lib/auth/optToken'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useLocale, useExtracted } from 'next-intl'
 
 let webAddress = process.env.NEXT_PUBLIC_API_URL
 
 const fetchOrders = async ({ pageParam = 1 }) => {
-  const otpToken = Cookies.get('opt_token')
+  // Recover the token from localStorage when the cookie lapsed, otherwise the
+  // request goes out as `Bearer undefined` and my-orders returns empty even
+  // though the user is still logged in (DAV-619). Same fix as order details.
+  const otpToken = getOptToken()
   axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
   const { data } = await axios.get(
     `${webAddress}/api/my-orders?page=${pageParam}`,
@@ -217,7 +220,9 @@ const OrdersApp: FC = () => {
             <div className="flex items-start justify-between mb-4">
               <div>
                 <Link
-                  href={`/${activeCity?.slug}/order/${hashids.encode(order.id)}`}
+                  href={`/${activeCity?.slug}/order/${hashids.encode(
+                    order.id
+                  )}`}
                   className="text-blue-600 font-semibold text-lg hover:text-blue-700 hover:underline"
                 >
                   Заказ № {order.id}

--- a/lib/utils/pickProductName.ts
+++ b/lib/utils/pickProductName.ts
@@ -1,0 +1,28 @@
+/**
+ * Safely extract a product's localized display name from the backend
+ * `attribute_data.name[channel][locale]` shape.
+ *
+ * The raw access `product.attribute_data.name[channel][locale]` throws a
+ * TypeError when any segment is missing — which happens for optimistically
+ * added lines and recommendation items whose product shape is incomplete. A
+ * thrown error in a cart render hits the App Router error boundary
+ * ("Что-то пошло не так") and wipes the in-memory cart until a reload (DAV-624).
+ *
+ * This never throws: optional-chains the whole path and falls back to the
+ * channel's `ru` value, then the flat `product.name` / `custom_name` that
+ * optimistic lines always carry.
+ */
+export function pickProductName(
+  product: any,
+  channelName: string,
+  locale?: string
+): string {
+  const m = product?.attribute_data?.name?.[channelName]
+  return (
+    m?.[locale || 'ru'] ||
+    m?.['ru'] ||
+    product?.name ||
+    product?.custom_name ||
+    ''
+  )
+}


### PR DESCRIPTION
Batch of frontend fixes (deployed together).

- **DAV-625** reset flat/entrance/door_code when the delivery address changes (map pin or autocomplete), in checkout (OrdersApp) and the header picker (LocationPickerCore).
- **DAV-624** stop the add-to-cart crash ("Что-то пошло не так"): cart renders read product.attribute_data.name[channel][locale] unguarded and threw on optimistic/recommendation lines → error boundary wiped the cart. Add lib/utils/pickProductName (fully optional-chained) used in SmallCartApp/OrderAcceptApp.
- **DAV-622** show cart-page product images (donuts, Bayram set, some pizzas): use pickProductImage (falls back to product.image) instead of getAssetUrl(assets).
- **DAV-619** show profile orders when opt_token only lives in localStorage: use getOptToken() instead of Cookies.get so my-orders isn't called as `Bearer undefined`.

Verified: production build green (compile + typecheck + 98 SSG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)